### PR TITLE
Update names for Athens locality

### DIFF
--- a/data/117/561/273/1/1175612731.geojson
+++ b/data/117/561/273/1/1175612731.geojson
@@ -168,17 +168,20 @@
     "name:dty_x_preferred":[
         "\u090f\u0925\u0947\u0928\u094d\u0938"
     ],
+    "name:ell_en_x_variant":[
+        "Ath\u00ednai"
+    ],
     "name:ell_x_historical":[
         "\u0391\u03b8\u03ae\u03bd\u03b1\u03b9"
     ],
     "name:ell_x_preferred":[
-        "Ath\u00ednai"
+        "\u0391\u03b8\u03ae\u03bd\u03b1"
     ],
     "name:ell_x_variant":[
         "\u0391\u03b8\u03ae\u03bd\u03b1\u03b9",
         "\u0391\u03b8\u03b7\u03bd\u03b1\u03b9",
-        "\u0391\u03b8\u03ae\u03bd\u03b1",
-        "\u0391\u03b8\u03b7\u03bd\u03b1"
+        "\u0391\u03b8\u03b7\u03bd\u03b1",
+        "\u0391\u0398\u0397\u039d\u0391\u0399"
     ],
     "name:eng_ca_x_preferred":[
         "Athens"
@@ -931,9 +934,9 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1587427352,
+    "wof:lastmodified":1597098380,
     "wof:megacity":1,
-    "wof:name":"\u0391\u0398\u0397\u039d\u0391\u0399",
+    "wof:name":"Athens",
     "wof:parent_id":85684697,
     "wof:placetype":"locality",
     "wof:population":664046,


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1877.

Updates the `name:ell_*` names and `wof:name` properties in the locality record for [Athens](https://spelunker.whosonfirst.org/id/1175612731/).

No PIP work required, can merge once approved.