### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/101/857/593/101857593.geojson
+++ b/data/101/857/593/101857593.geojson
@@ -35,19 +35,20 @@
         "Elaioch\u00f3ri"
     ],
     "name:ell_x_preferred":[
-        "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9"
+        "\u0395\u039b\u0391\u0399\u039f\u03a7\u03a9\u03a1\u0399\u039f\u039d"
     ],
     "name:ell_x_variant":[
         "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9\u03bf\u03bd",
         "Elaioch\u00f3ri",
         "Elaioch\u00f3rion",
-        "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9 \u039a\u03b1\u03b2\u03ac\u03bb\u03b1\u03c2"
+        "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9 \u039a\u03b1\u03b2\u03ac\u03bb\u03b1\u03c2",
+        "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9"
     ],
     "name:eng_x_historical":[
         "\u039a\u03bf\u03c4\u03c3\u03ba\u03ac\u03c1"
     ],
     "name:eng_x_preferred":[
-        "\u039a\u03bf\u03c4\u03c3\u03ba\u03ac\u03c1"
+        "Elaiochori"
     ],
     "name:eng_x_variant":[
         "Elaiochori"
@@ -118,8 +119,8 @@
         }
     ],
     "wof:id":101857593,
-    "wof:lastmodified":1582360183,
-    "wof:name":"\u0395\u039b\u0391\u0399\u039f\u03a7\u03a9\u03a1\u0399\u039f\u039d",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Elaiochori",
     "wof:parent_id":85684701,
     "wof:placetype":"locality",
     "wof:population":1195,

--- a/data/101/857/593/101857593.geojson
+++ b/data/101/857/593/101857593.geojson
@@ -37,20 +37,10 @@
     "name:ell_x_preferred":[
         "\u0395\u039b\u0391\u0399\u039f\u03a7\u03a9\u03a1\u0399\u039f\u039d"
     ],
-    "name:ell_x_variant":[
-        "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9\u03bf\u03bd",
-        "Elaioch\u00f3ri",
-        "Elaioch\u00f3rion",
-        "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9 \u039a\u03b1\u03b2\u03ac\u03bb\u03b1\u03c2",
-        "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9"
-    ],
     "name:eng_x_historical":[
         "\u039a\u03bf\u03c4\u03c3\u03ba\u03ac\u03c1"
     ],
     "name:eng_x_preferred":[
-        "Elaiochori"
-    ],
-    "name:eng_x_variant":[
         "Elaiochori"
     ],
     "name:mkd_x_preferred":[
@@ -119,7 +109,7 @@
         }
     ],
     "wof:id":101857593,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423094,
     "wof:name":"Elaiochori",
     "wof:parent_id":85684701,
     "wof:placetype":"locality",

--- a/data/101/857/593/101857593.geojson
+++ b/data/101/857/593/101857593.geojson
@@ -35,7 +35,13 @@
         "Elaioch\u00f3ri"
     ],
     "name:ell_x_preferred":[
-        "\u0395\u039b\u0391\u0399\u039f\u03a7\u03a9\u03a1\u0399\u039f\u039d"
+        "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9"
+    ],
+    "name:ell_x_variant":[
+        "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9\u03bf\u03bd",
+        "Elaioch\u00f3ri",
+        "Elaioch\u00f3rion",
+        "\u0395\u03bb\u03b1\u03b9\u03bf\u03c7\u03ce\u03c1\u03b9 \u039a\u03b1\u03b2\u03ac\u03bb\u03b1\u03c2"
     ],
     "name:eng_x_historical":[
         "\u039a\u03bf\u03c4\u03c3\u03ba\u03ac\u03c1"
@@ -109,7 +115,7 @@
         }
     ],
     "wof:id":101857593,
-    "wof:lastmodified":1601423094,
+    "wof:lastmodified":1601427419,
     "wof:name":"Elaiochori",
     "wof:parent_id":85684701,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.