### PR TITLE
WIP: Move centroids inside geometries

### DIFF
--- a/data/859/026/67/85902667.geojson
+++ b/data/859/026/67/85902667.geojson
@@ -13,8 +13,8 @@
     "gn:longitude":23.73755,
     "gn:population":2096,
     "iso:country":"GR",
-    "lbl:latitude":38.001478,
-    "lbl:longitude":23.739346,
+    "lbl:latitude":38.002656,
+    "lbl:longitude":23.733276,
     "lbl:max_zoom":18.0,
     "mps:latitude":38.002656,
     "mps:longitude":23.733276,
@@ -117,7 +117,7 @@
     "src:geom_alt":[
         "quattroshapes_pg"
     ],
-    "src:lbl_centroid":"mz",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "wd:latitude":38.000236,
     "wd:longitude":23.739056,
@@ -157,7 +157,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1690924073,
+    "wof:lastmodified":1694320460,
     "wof:name":"Kypseli",
     "wof:parent_id":1175612731,
     "wof:placetype":"neighbourhood",

--- a/data/859/026/85/85902685.geojson
+++ b/data/859/026/85/85902685.geojson
@@ -12,11 +12,11 @@
     "gn:latitude":38.03333,
     "gn:longitude":23.73333,
     "iso:country":"GR",
-    "lbl:latitude":38.017733,
-    "lbl:longitude":23.736233,
+    "lbl:latitude":38.017324,
+    "lbl:longitude":23.746571,
     "lbl:max_zoom":18.0,
     "mps:latitude":38.017324,
-    "mps:longitude":23.746583,
+    "mps:longitude":23.746571,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:is_funky":0,
@@ -110,7 +110,7 @@
     "src:geom_alt":[
         "quattroshapes_pg"
     ],
-    "src:lbl_centroid":"mz",
+    "src:lbl_centroid":"mapshaper",
     "wd:latitude":38.033333,
     "wd:longitude":23.733333,
     "wd:wordcount":257,
@@ -146,7 +146,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1690924077,
+    "wof:lastmodified":1694320460,
     "wof:name":"Patisia",
     "wof:parent_id":1175612731,
     "wof:placetype":"neighbourhood",

--- a/data/859/063/73/85906373.geojson
+++ b/data/859/063/73/85906373.geojson
@@ -11,8 +11,8 @@
     "geom:longitude":23.741094,
     "gn:id":"",
     "iso:country":"GR",
-    "lbl:latitude":37.99806,
-    "lbl:longitude":23.756695,
+    "lbl:latitude":37.99803,
+    "lbl:longitude":23.741224,
     "lbl:max_zoom":18.0,
     "mps:latitude":37.99803,
     "mps:longitude":23.741224,
@@ -81,7 +81,7 @@
     "src:geom_alt":[
         "quattroshapes_pg"
     ],
-    "src:lbl_centroid":"mz",
+    "src:lbl_centroid":"mapshaper",
     "wd:latitude":37.998462,
     "wd:longitude":23.758793,
     "wd:wordcount":26,
@@ -114,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1690924066,
+    "wof:lastmodified":1694320460,
     "wof:name":"Polygono",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/077/23/85907723.geojson
+++ b/data/859/077/23/85907723.geojson
@@ -11,8 +11,8 @@
     "geom:longitude":23.719942,
     "gn:id":"",
     "iso:country":"GR",
-    "lbl:latitude":37.978798,
-    "lbl:longitude":23.724155,
+    "lbl:latitude":37.981301,
+    "lbl:longitude":23.719858,
     "lbl:max_zoom":18.0,
     "mps:latitude":37.981301,
     "mps:longitude":23.719858,
@@ -104,7 +104,7 @@
     "src:geom_alt":[
         "quattroshapes_pg"
     ],
-    "src:lbl_centroid":"mz",
+    "src:lbl_centroid":"mapshaper",
     "wd:latitude":37.977778,
     "wd:longitude":23.725,
     "wd:wordcount":251,
@@ -138,7 +138,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1690924063,
+    "wof:lastmodified":1694320460,
     "wof:name":"Psyri",
     "wof:parent_id":1175612731,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2159.

This PR updates records with label centroids that fall outside of a geometry. The new label centroid comes from Mapshaper, the `src:lbl_centroid` property has been updated, too.

This PR will require PIP work before merge.