### PR TITLE
gr concordances, placetype local, and more

### DIFF
--- a/data/136/066/603/1/1360666031.geojson
+++ b/data/136/066/603/1/1360666031.geojson
@@ -206,8 +206,10 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"EL41"
+        "eurostat:nuts_2021_id":"EL41",
+        "iso:code":"GR-K"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GR",
     "wof:geomhash":"d3d94ea3a524dc589ad12f6274fe57d8",
     "wof:hierarchy":[
@@ -224,7 +226,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351434,
+    "wof:lastmodified":1695885171,
     "wof:name":"North Aegean",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/136/066/603/9/1360666039.geojson
+++ b/data/136/066/603/9/1360666039.geojson
@@ -5,8 +5,8 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036518,
-    "geom:area_square_m":344546594.55327,
-    "geom:bbox":"23.99290649999978,40.11372449999984,24.40486899999976,40.45344199999985",
+    "geom:area_square_m":344546594.553276,
+    "geom:bbox":"23.9929065,40.1137245,24.404869,40.453442",
     "geom:latitude":40.268112,
     "geom:longitude":24.198975,
     "iso:country":"GR",
@@ -252,9 +252,12 @@
         85633171
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code":"GR-69"
+    },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GR",
-    "wof:geomhash":"409906d6de08cccdb94aa6276671e361",
+    "wof:geomhash":"48c1a23ea3de4c779882a0a4230f0ef5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -269,7 +272,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1602619681,
+    "wof:lastmodified":1695884442,
     "wof:name":"Mount Athos",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/331/71/85633171.geojson
+++ b/data/856/331/71/85633171.geojson
@@ -1366,6 +1366,7 @@
         "hasc:id":"GR",
         "icao:code":"SX",
         "ioc:id":"GRE",
+        "iso:code":"GR",
         "itu:id":"GRC",
         "loc:id":"n80046090",
         "m49:code":"300",
@@ -1380,6 +1381,7 @@
         "wk:page":"Greece",
         "wmo:id":"GR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GR",
     "wof:country_alpha3":"GRC",
     "wof:geom_alt":[
@@ -1401,7 +1403,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1694492229,
+    "wof:lastmodified":1695881342,
     "wof:name":"Greece",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/846/21/85684621.geojson
+++ b/data/856/846/21/85684621.geojson
@@ -231,8 +231,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"EL63"
+        "eurostat:nuts_2021_id":"EL63",
+        "iso:code":"GR-G",
+        "qs:local_id":"07"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geom_alt":[
         "quattroshapes"
@@ -252,7 +258,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351425,
+    "wof:lastmodified":1695885161,
     "wof:name":"Western Greece",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/846/27/85684627.geojson
+++ b/data/856/846/27/85684627.geojson
@@ -142,8 +142,14 @@
         "fips:code":"GR08",
         "gn:id":6697811,
         "gp:id":12577881,
-        "hasc:id":"GR.MW"
+        "hasc:id":"GR.MW",
+        "iso:code":"GR-C",
+        "qs:local_id":"03"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geomhash":"b3dea3af6818c7731c2bf825a1d0f48d",
     "wof:hierarchy":[
@@ -160,7 +166,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351426,
+    "wof:lastmodified":1695885161,
     "wof:name":"West Macedonia",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/846/31/85684631.geojson
+++ b/data/856/846/31/85684631.geojson
@@ -144,8 +144,14 @@
         "gn:id":6697804,
         "gp:id":12577883,
         "hasc:id":"GR.EP",
+        "iso:code":"GR-D",
+        "qs:local_id":"04",
         "wd:id":"Q7233875"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geomhash":"7f88f5aa596ba7feee24601713d7bd3d",
     "wof:hierarchy":[
@@ -162,7 +168,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351426,
+    "wof:lastmodified":1695885162,
     "wof:name":"Epirus",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/846/37/85684637.geojson
+++ b/data/856/846/37/85684637.geojson
@@ -302,8 +302,14 @@
         "fips:code":"GR05",
         "gn:id":6697801,
         "gp:id":12577884,
-        "hasc:id":"GR.MC"
+        "hasc:id":"GR.MC",
+        "iso:code":"GR-B",
+        "qs:local_id":"02"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geom_alt":[
         "quattroshapes"
@@ -323,7 +329,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351426,
+    "wof:lastmodified":1695885162,
     "wof:name":"Central Macedonia",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/846/43/85684643.geojson
+++ b/data/856/846/43/85684643.geojson
@@ -349,8 +349,14 @@
         "fips:code":"GR36",
         "gn:id":6697807,
         "gp:id":12577887,
-        "hasc:id":"GR.PP"
+        "hasc:id":"GR.PP",
+        "iso:code":"GR-J",
+        "qs:local_id":"10"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geom_alt":[
         "quattroshapes"
@@ -370,7 +376,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351426,
+    "wof:lastmodified":1695885162,
     "wof:name":"Peloponnese",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/846/55/85684655.geojson
+++ b/data/856/846/55/85684655.geojson
@@ -469,8 +469,14 @@
         "fips:code":"GR43",
         "gn:id":6697802,
         "gp:id":12577885,
-        "hasc:id":"GR.CR"
+        "hasc:id":"GR.CR",
+        "iso:code":"GR-M",
+        "qs:local_id":"13"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geomhash":"39381f811d599da11b1c0e9553872b8c",
     "wof:hierarchy":[
@@ -487,7 +493,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351426,
+    "wof:lastmodified":1695885162,
     "wof:name":"Crete",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/846/59/85684659.geojson
+++ b/data/856/846/59/85684659.geojson
@@ -222,8 +222,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"EL42"
+        "eurostat:nuts_2021_id":"EL42",
+        "iso:code":"GR-L",
+        "qs:local_id":"12"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geomhash":"717a295012827654cae42bc7b3ea7438",
     "wof:hierarchy":[
@@ -240,7 +246,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351427,
+    "wof:lastmodified":1695885163,
     "wof:name":"South Aegean",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/846/81/85684681.geojson
+++ b/data/856/846/81/85684681.geojson
@@ -191,8 +191,14 @@
         "fips:code":"GR33",
         "gn:id":6697800,
         "gp:id":12577888,
-        "hasc:id":"GR.GC"
+        "hasc:id":"GR.GC",
+        "iso:code":"GR-H",
+        "qs:local_id":"08"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geom_alt":[
         "quattroshapes"
@@ -212,7 +218,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351432,
+    "wof:lastmodified":1695885169,
     "wof:name":"Central Greece",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/846/85/85684685.geojson
+++ b/data/856/846/85/85684685.geojson
@@ -386,13 +386,19 @@
         "gn:id":6697809,
         "gp:id":12577889,
         "hasc:id":"GR.TS",
+        "iso:code":"GR-E",
+        "qs:local_id":"05",
         "wd:id":"Q166919"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"90fcffcb2fc2715f652bdb60be2a0afa",
+    "wof:geomhash":"d150752d0413ba0de30c4a761e44e2b2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -407,7 +413,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1690924083,
+    "wof:lastmodified":1695885169,
     "wof:name":"Thessaly",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/846/93/85684693.geojson
+++ b/data/856/846/93/85684693.geojson
@@ -252,8 +252,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"EL62"
+        "eurostat:nuts_2021_id":"EL62",
+        "iso:code":"GR-F",
+        "qs:local_id":"06"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geom_alt":[
         "quattroshapes"
@@ -273,7 +279,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351434,
+    "wof:lastmodified":1695885170,
     "wof:name":"Ionian Islands",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/846/97/85684697.geojson
+++ b/data/856/846/97/85684697.geojson
@@ -252,8 +252,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"EL30"
+        "eurostat:nuts_2021_id":"EL30",
+        "iso:code":"GR-I",
+        "qs:local_id":"09"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geomhash":"4b26b3ad1364482806967278bc7479e8",
     "wof:hierarchy":[
@@ -270,7 +276,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351434,
+    "wof:lastmodified":1695885170,
     "wof:name":"Attica",
     "wof:parent_id":85633171,
     "wof:placetype":"region",

--- a/data/856/847/01/85684701.geojson
+++ b/data/856/847/01/85684701.geojson
@@ -145,8 +145,14 @@
         "fips:code":"GR01",
         "gn:id":6697803,
         "gp:id":12577878,
-        "hasc:id":"GR.MT"
+        "hasc:id":"GR.MT",
+        "iso:code":"GR-A",
+        "qs:local_id":"01"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"GR",
     "wof:geom_alt":[
         "quattroshapes"
@@ -166,7 +172,7 @@
     "wof:lang_x_spoken":[
         "ell"
     ],
-    "wof:lastmodified":1684351434,
+    "wof:lastmodified":1695885171,
     "wof:name":"East Macedonia and Thrace",
     "wof:parent_id":85633171,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.